### PR TITLE
Added Optional branchName argument

### DIFF
--- a/commands/pr.js
+++ b/commands/pr.js
@@ -15,7 +15,7 @@ const {
   fetchIssueDetailsFromJira,
 } = require("../utils/http");
 
-const pr = async (jiraUrl) => {
+const pr = async (jiraUrl, newBranchName) => {
   try {
     const environmentVariables = getEnvVariables();
     const jiraKey = getJiraIssueKeyFromUrl(jiraUrl);
@@ -34,7 +34,9 @@ const pr = async (jiraUrl) => {
     }
 
     const { fields: { summary = "" } = {}, key = "" } = issueDetails; // get relevant fields
-    const branchName = branchify(key, summary);
+
+    //passing the optional branch name if it exists.
+    const branchName = newBranchName ? newBranchName : branchify(key, summary);
 
     const onClean = await onCleanBranch();
     if (!onClean) return;

--- a/index.js
+++ b/index.js
@@ -6,7 +6,9 @@ const pr = require("./commands/pr");
 program
   .name("pfi")
   .description("Creates a new Pull Request when given a Jira Issue URL")
-  .arguments("<string>", "Jira Issue URL")
-  .action(pr);
+  .arguments("<jiraUrl> [newBranchName]") // Updated to include optional branch name
+  .action((jiraUrl, newBranchName) => {
+    pr(jiraUrl, newBranchName); // Pass both arguments to the `pr` function
+  });
 
 program.parse();

--- a/utils/tools.js
+++ b/utils/tools.js
@@ -7,7 +7,7 @@ const branchify = (key, summary) => {
 
   return `${lowerKey}-${lowerSummary}`
     .replace(/[^a-z0-9-]/g, "") // removes anything that is not alphanumeric or a hyphen
-    .slice(0, 50) // max length 50 characters for branch
+    .slice(0, 25) // max length 25 characters for branch, to avoid invalid deployed URL
     .trim(); // remove whitespace
 };
 


### PR DESCRIPTION
This code:
- adds an optional `newBranchName` argument.
- reduces the branchName length to 25 characters to avoid invalid deployed URL in case the optional argument is not passed.